### PR TITLE
Fix the handling of the ignored account table

### DIFF
--- a/Horizon.Database/Controllers/AccountController.cs
+++ b/Horizon.Database/Controllers/AccountController.cs
@@ -118,7 +118,7 @@ namespace Horizon.Database.Controllers
                     AccountId = ignoredId,
                     AccountName = accountList.Where(a => a.AccountId == ignoredId).Select(a => a.AccountName).FirstOrDefault()
                 };
-                account2.Friends.Add(friendDTO);
+                account2.Ignored.Add(friendDTO);
             }
 
             return account2;


### PR DESCRIPTION
The iteration of the ignored accounts part in the "getAccount" function is incorrect.

It returns the result in Friends instead of Ignored.

This commit fixes that.

Before (Master) : 
![image](https://user-images.githubusercontent.com/42487204/168440638-b754a0a0-68cf-4d8b-be04-e9c8880fd2ad.png)

After (PR) :
![image](https://user-images.githubusercontent.com/42487204/168440651-8bb4a1b1-0fcc-4b8d-8e73-1203a6223d02.png)
